### PR TITLE
Change template vector of size<2> to template<N>

### DIFF
--- a/test/util.hpp
+++ b/test/util.hpp
@@ -577,7 +577,7 @@ void HyperSphereBoundaryCells(
     auto const neighbor_offset_end = end(face_neighbor_offsets);
 
     auto old_foreground_indices = foreground_indices;
-    auto new_foreground_indices = vector<array<int32_t, 2>>{};
+    auto new_foreground_indices = vector<array<int32_t, N>>{};
     for (auto i = size_t{0}; i < dilation_pass_count; ++i) {
       for (auto const foreground_index : old_foreground_indices) {
         for (auto neighbor_offset_iter = neighbor_offset_begin;
@@ -604,7 +604,7 @@ void HyperSphereBoundaryCells(
     }
 
     old_foreground_indices = new_foreground_indices;
-    new_foreground_indices = vector<array<int32_t, 2>>{};
+    new_foreground_indices = vector<array<int32_t, N>>{};
   }
 }
 


### PR DESCRIPTION
In a template class a vector is declared of what appears to be a fixed
size of 2 dimensions. Test code declares the template with 3 dimensions,
which causes errors when pushing values onto this vector.

It is not that clear to me that this is correct. This should work if
using data of 2 dimensions, but that may be a coincidence. That the
vector is populated using an N-bounded loop for the neighbor_index
suggests that this is a correct solution.